### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ cd ..
 
 Download and compile Janus
 ```bash
-git clone git@github.com:meetecho/janus-gateway.git
+git clone https://github.com/meetecho/janus-gateway.git
 cd janus-gateway
 sh autogen.sh
-./configure --prefix=/opt/janus --disable-websockets --disable-rabbitmq
+./configure --prefix=/opt/janus --disable-websockets --disable-rabbitmq --disable-aes-gcm
 make
 sudo make install
 sudo make configs


### PR DESCRIPTION
I just reinstalled Janus, and had to do two things different:

1. I did a git clone from `https://` instead of `git@`, because https:// doesn't require a github login.
2. Janus now [expects some features from libsrtp that aren't always enabled, or it won't build](https://janus.conf.meetecho.com/docs/FAQ#aesgcm). So I disabled them with `--disable-aes-gcm`. We don't use that, do we?